### PR TITLE
pre-commit: enable yaml checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: check-json
-  # - id: check-yaml
+  - id: check-yaml
   - id: sort-simple-yaml
   - id: check-xml
   - id: check-merge-conflict


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Related to https://github.com/pre-commit/pre-commit-hooks/issues/710 . Fixed on `ruamel.yaml==0.17.20`.